### PR TITLE
Add cudaHashcat v2.01 (oclHashcat for NVIDIA)

### DIFF
--- a/archstrike-testing/cudahashcat/PKGBUILD
+++ b/archstrike-testing/cudahashcat/PKGBUILD
@@ -1,0 +1,49 @@
+#Maintainer:  ArchStrike <team@archstrike.org>
+
+groups=('archstrike' 'archstrike-crackers')
+pkgname='cudahashcat'
+_pkgname='cudaHashcat'
+pkgver=2.01
+pkgrel=1
+pkgdesc='Worlds fastest WPA cracker with dictionary mutation engine'
+url='http://hashcat.net/oclhashcat/'
+arch=('i686' 'x86_64')
+license=('custom')
+depends=('bash' 'libcl' 'nvidia-utils>=346.59')
+source=("http://hashcat.net/files/$_pkgname-$pkgver.7z")
+sha512sums=('027dbe92a085bc4b115cc8c3705510084dab556292df9f12168cd3f6796a730a77573056a95607a58d8f6527bb91a277861b07b49a941dcc2883e2c94cfb7edf')
+options=('!strip')
+
+package() {
+  # Copy files
+  install -dm755 "$pkgdir/opt/$pkgname"
+  cp -a --no-preserve=ownership  $_pkgname-$pkgver/* "$pkgdir/opt/$pkgname/"
+  cd "$pkgdir/opt/$pkgname"
+
+  # Set up bash pivot
+  install -dm755 "$pkgdir/usr/bin"
+  if [ "$CARCH" = "x86_64" ]; then
+    rm ${_pkgname}32.bin
+    echo -e "#!/bin/bash\n/opt/$pkgname/${_pkgname}64.bin \$@" > "$pkgdir/usr/bin/$_pkgname"
+  else
+    rm ${_pkgname}64.bin
+    echo -e "#!/bin/bash\n/opt/$pkgname/${_pkgname}32.bin \$@" > "$pkgdir/usr/bin/$_pkgname"
+  fi
+  chmod a+x "$pkgdir/usr/bin/$_pkgname"
+
+  # Get rid of windows stuff
+  find . \( -name "*.cmd" -o -name "*.exe" \) -exec rm '{}' \;
+
+  # Cleanup permissions
+  find "$pkgdir" -iname '*.txt' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.llvmir' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.hash' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.sh' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.rule' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.hcmask' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.hcstat' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.dict' -exec chmod 644 '{}' \;
+  find "$pkgdir" -iname '*.bin' -exec chmod 755 '{}' \;
+}
+
+


### PR DESCRIPTION
Current oclHashcat version is no longer supported, and did not work with NVIDA chipsets.  Recommend splitting package into oclhashcat (AMD/Catalyst), and cudahashcat (NVIDIA) to match vendor naming convention.  Temporary fix until oclhashcat-git is in a better state, and opencl dependencies are working correctly.