### PR TITLE
Fixed PKGBUILD file for nsia

### DIFF
--- a/archstrike-testing/nsia/PKGBUILD
+++ b/archstrike-testing/nsia/PKGBUILD
@@ -2,6 +2,8 @@
 
 buildarch=1
 
+DLAGENTS=("http::/usr/bin/curl -k -fLC - --retry 3 --retry-delay 3 -o %o %u")
+
 pkgname=nsia
 pkgver=1.0.6
 pkgrel=5


### PR DESCRIPTION
The SSL certificate of the source website http://threatfactor.com is expired. Added DLAGENTS so that curl pulls source without checking certificate.