### PR TITLE
Fixed issue with pkg trid

### DIFF
--- a/archstrike-testing/trid/PKGBUILD
+++ b/archstrike-testing/trid/PKGBUILD
@@ -8,21 +8,24 @@ pkgrel=5
 pkgdesc="Utility to identify file types using their binary signatures"
 arch=('armv6h' 'armv7h' 'i686' 'x86_64')
 url="http://mark0.net/soft-trid-e.html"
-groups=('archstrike')
+groups=('archstrike' 'archstrike-misc')
 license=('CUSTOM')
 depends=('trid-defs' 'bash')
 depends_i686+=('ncurses')
-depends_x86_64+=('lib32-ncurses' 'gcc-multilib')
+depends_x86_64+=('lib32-ncurses')
 
 source=("http://mark0.net/download/trid_linux.zip"
         "${pkgname}.sh"
         "${pkgname}.desktop")
-sha512sums=('95f067c7da02a5a753f6f213a015da7f498be38ac682db4565c3a198fc626d5195dd88c3079f9c742a44249e81a4431057812d79733b84633333604a77f10b4f'
+sha512sums=('63f732241214e0975413191e60dd94a3b008af9c5b93eeeef7bf13ee43dedc4b6cbf50484fcd46378342fb26f369c3b1b8ca82ce618e9dfabeae841255b8e077'
             '4a5484cb0b47436dc58a3132d76ff2ec2c4f3c564af5c827854571bafce5b82bb2ef023b387b465cbb114cfaf1b47d54666da7bd2a954a9160e95a41a74930a8'
             '4162bdc2462ffa0b408bde13aed495c6c9aa39f292d27316a36c1e7816bebcf0a71190f313468a09198b6e8b84b72d113624392631d2276353ca805c7b985f9d')
 
+prepare() {
+    execstack -c trid
+}
 package() {
-    install -Dm755 $pkgname "${pkgdir}/usr/share/${pkgname}/${pkgname}"
+    install -Dm755 ${pkgname} "${pkgdir}/usr/share/${pkgname}/${pkgname}"
     install -Dm755 ${pkgname}.sh "${pkgdir}/usr/bin/${pkgname}"
     install -Dm755 ${pkgname}.desktop "${pkgdir}/usr/share/applications/${pkgname}.desktop"
     install -Dm644 readme.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"


### PR DESCRIPTION
Fixed weird build issue on x86_64 by removing 'gcc-multilibs' dependency. Fixed executable stack issue on binary.