### PR TITLE
[simple-email-spoofer-git] Fix argument file becoming incorrect after the cd.

### DIFF
--- a/archstrike/simple-email-spoofer-git/PKGBUILD
+++ b/archstrike/simple-email-spoofer-git/PKGBUILD
@@ -4,7 +4,7 @@ buildarch=1
 
 pkgname=simple-email-spoofer-git
 pkgver=20161120.r50
-pkgrel=1
+pkgrel=2
 groups=('archstrike' 'archstrike-spoof')
 arch=('any')
 pkgdesc="A simple Python CLI to spoof emails."
@@ -35,8 +35,7 @@ package() {
 
 cat > "$pkgdir/usr/bin/simple-email-spoofer" <<EOF
 #!/usr/bin/env bash
-cd /usr/share/$pkgname
-python2 SimpleEmailSpoofer.py "\$@"
+python2 /usr/share/$pkgname/SimpleEmailSpoofer.py "\$@"
 EOF
 chmod 755 "$pkgdir/usr/bin/simple-email-spoofer"
 }


### PR DESCRIPTION
The -e [FILE] argument would become invalid after the cd if you happened to put a relative path.
The patch is simple: just call the entire script from an absolute path, and avoid moving between folders.

Comments and remarks are welcome for sure :-)