### PR TITLE
added pkgbuild for honeypy

### DIFF
--- a/archstrike/honeypy/PKGBUILD
+++ b/archstrike/honeypy/PKGBUILD
@@ -1,0 +1,41 @@
+#First sample build
+
+buildarch=1
+
+pkgname=honeypy-git
+pkgver=20161130.r271
+pkgrel=1
+pkgdesc="A low interaction Honeypot"
+arch=('any')
+url="https://github.com/foospidy/HoneyPy"
+license=('GPL')
+groups=('archstrike' 'archstrike-honeypots' 'archstrike-defense')
+depends=('python2' 'python2-dnslib' 'python2-requests' 'python2-twisted' 'python2-certifi' 'python2-urllib3')
+makedepends=('git')
+source=("${pkgname}::git+${url}.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "$pkgname"
+  printf "%s.r%s" "$(git show -s --format=%ci master | sed 's/\ .*//g;s/-//g')" "$(git rev-list --count HEAD)"
+}
+
+prepare() {
+  cd "$pkgname"
+  sed -i 's|python|python2|' Honey.py
+}
+
+package() {
+  cd "$pkgname"
+  install -dm755 "${pkgdir}/usr/bin"
+  install -dm755 "${pkgdir}/usr/share/${pkgname}"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}"
+  cp -a --no-preserve=ownership * "$pkgdir/usr/share/$pkgname"
+  
+cat > "${pkgdir}/usr/bin/honeypy" <<EOF
+#!/usr/bin/env bash
+cd /usr/share/${pkgname}
+python2 Honey.py "\$@"
+EOF
+  chmod 755 "$pkgdir/usr/bin/honeypy"
+}


### PR DESCRIPTION
This is my first pull request for the package HoneyPy which is a low interaction honeypot. 
It relies on, python2, python2-{dnslib,requests,twisted,certify,urllib3}
The arch executable is located at /usr/bin/honeypy which lauches the python script HoneyPy.py using python2. 

