### PR TITLE
added PKGBUILD for autobrowser release vers 3.0

### DIFF
--- a/archstrike-testing/autobrowser-git/PKGBUILD
+++ b/archstrike-testing/autobrowser-git/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: ArchStrike <team@archstrike.org>
+
+buildarch=1
+
+pkgname=autobrowser-git
+pkgver=20161027.r24
+pkgrel=1
+pkgdesc="A python analysing and reporting tool for pentesters"
+arch=('any')
+url="https://github.com/El3ct71k/AutoBrowser"
+license=('GPL')
+groups=('archstrike' 'archstrike-scanners' 'archstrike-recon' 'archstrike-analysis')
+depends=('python2' 'python2-nmap' 'ghost.py' 'python2-colorlog' 'python2-pyqt4')
+makedepends=('git')
+source=("${pkgname}::git+${url}.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "$pkgname"
+  printf "%s.r%s" "$(git show -s --format=%ci master | sed 's/\ .*//g;s/-//g')" "$(git rev-list --count HEAD)"
+}
+
+prepare() {
+  cd "$pkgname"
+  sed -i 's|python$|python2|' AutoBrowser.py
+}
+
+package() {
+  cd "$pkgname"
+  install -dm755 "${pkgdir}/usr/bin"
+  install -dm755 "${pkgdir}/usr/share/${pkgname}"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}"
+  cp -a --no-preserve=ownership * "$pkgdir/usr/share/$pkgname"
+  
+cat > "${pkgdir}/usr/bin/autobrowser" <<EOF
+#!/usr/bin/env bash
+cd /usr/share/${pkgname}
+python2 AutoBrowser.py "\$@"
+EOF
+  chmod 755 "$pkgdir/usr/bin/autobrowser"
+}


### PR DESCRIPTION
This is the PKGBUILD for autobrowser , a pentesting tool for reporting and analysing. 
Depends on python2, python2-nmap, ghost.py  and python2-colorlog.
invocation script is at /usr/bin/autobrowser which inturn launches AutoBrowser.py using python2. 