### PR TITLE
Fix chdir call of brutessh causing rights and paths issues.

### DIFF
--- a/archstrike/brutessh/PKGBUILD
+++ b/archstrike/brutessh/PKGBUILD
@@ -4,7 +4,7 @@ buildarch=1
 
 pkgname=brutessh
 pkgver=0.6
-pkgrel=2
+pkgrel=3
 pkgdesc="A simple sshd password bruteforcer using a wordlist, it's very fast for internal networks. It's multithreads."
 url="http://www.edge-security.com/edge-soft.php"
 groups=('archstrike' 'archstrike-crackers')
@@ -18,14 +18,13 @@ package() {
   cd "$srcdir/brutessh"
 
   install -dm755 "$pkgdir/usr/bin"
-  install -dm755 "$pkgdir/usr/share/brutessh"
+  install -dm755 "$pkgdir/usr/share/$pkgname"
 
-  cp --no-preserve=ownership -R README brutessh.py terminal.py "$pkgdir/usr/share/brutessh/"
+  cp --no-preserve=ownership -R README brutessh.py terminal.py "$pkgdir/usr/share/$pkgname/"
   cat > $pkgdir/usr/bin/brutessh << EOF
 #!/bin/sh
-cd /usr/share/brutessh
-python2 brutessh.py "\$@"
+python2 /usr/share/$pkgname/brutessh.py "\$@"
 EOF
   chmod +x $pkgdir/usr/bin/brutessh
-  chmod +x $pkgdir/usr/share/brutessh/brutessh.py
+  chmod +x $pkgdir/usr/share/$pkgname/brutessh.py
 }


### PR DESCRIPTION
With the previous chdir, the `-d mypasswordlist.txt` argument would not have been parsed correctly when given a relative path to the word list file as well demo.log would have no rights to be created into /usr/share/brutessh/ (unless executing this script as root, which you probably should not be doing).

I also did a bit of cleanup and replaced the /usr/share/brutessh/ hardcoded folder to $pkgname. It makes more sense to me. I just hope it is okay for you too.

Comments and remarks are welcome as usual.