### PR TITLE
Update .gitignore for ciphertest-git

### DIFF
--- a/archstrike/ciphertest-git/.gitignore
+++ b/archstrike/ciphertest-git/.gitignore
@@ -1,1 +1,1 @@
-ciphertest
+ciphertest-git


### PR DESCRIPTION
Code is cloned under ciphertest-git, not ciphertest. Update accordingly the .gitignore.