### PR TITLE
Updating BurpSuite version

### DIFF
--- a/archstrike/burpsuite/PKGBUILD
+++ b/archstrike/burpsuite/PKGBUILD
@@ -3,7 +3,7 @@
 buildarch=1
 
 pkgname=burpsuite
-pkgver=1.7.26
+pkgver=1.7.27
 pkgrel=1
 groups=('archstrike' 'archstrike-webapps' 'archstrike-scanners' 'archstrike-fuzzers' 'archstrike-proxy')
 pkgdesc="An integrated platform for attacking web applications (free edition)."
@@ -13,7 +13,7 @@ arch=('any')
 license=('custom')
 noextract=("burpsuite.jar")
 source=("burpsuite.jar::https://portswigger.net/Burp/Releases/Download?productId=100&version=${pkgver}&type=Jar" "LICENSE")
-sha512sums=('f0b6dc0a4af469e719e80b28c1db7ea2e908e81890b75745ca1fb31fab3342a7c966f0f5bc09058e6f15f71fff41dae08fee42267d6fdf9a4cbd1af8a9d866e1'
+sha512sums=('17f39e21bf0039480c27659ef775f144d446078a954776dc753791157132502003dceef878e0c92f0471bb698701c78df5e25ed4ba2e570a40105b5583f090c4'
             '37abc24b19571bfd2941e3dd7aa8a8a330bd3bbbafb3d1f813035ab0313e189c1f4a43a68f820a32656b86dd29cca94afcaefc6a4bfb4219ef18dc0fc4923b86')
 
 package() {

--- a/archstrike/burpsuite/PKGBUILD
+++ b/archstrike/burpsuite/PKGBUILD
@@ -3,7 +3,7 @@
 buildarch=1
 
 pkgname=burpsuite
-pkgver=1.7.19
+pkgver=1.7.26
 pkgrel=1
 groups=('archstrike' 'archstrike-webapps' 'archstrike-scanners' 'archstrike-fuzzers' 'archstrike-proxy')
 pkgdesc="An integrated platform for attacking web applications (free edition)."
@@ -13,7 +13,7 @@ arch=('any')
 license=('custom')
 noextract=("burpsuite.jar")
 source=("burpsuite.jar::https://portswigger.net/Burp/Releases/Download?productId=100&version=${pkgver}&type=Jar" "LICENSE")
-sha512sums=('88b9890ef87e4b8fd40fcebbe3f7ce1db42f00080523b3df78d88229c80a1db17738f28cf5b16aedc68bab8ab5e729fb69cfd4e8c630a469346761a375ef55a3'
+sha512sums=('f0b6dc0a4af469e719e80b28c1db7ea2e908e81890b75745ca1fb31fab3342a7c966f0f5bc09058e6f15f71fff41dae08fee42267d6fdf9a4cbd1af8a9d866e1'
             '37abc24b19571bfd2941e3dd7aa8a8a330bd3bbbafb3d1f813035ab0313e189c1f4a43a68f820a32656b86dd29cca94afcaefc6a4bfb4219ef18dc0fc4923b86')
 
 package() {


### PR DESCRIPTION
Updating BurpSuite version to the most recent version. The current version available on the repository does not allow to use SSL interception on Chrome (not confirmed with other browsers, but it might cause problems too)