### PR TITLE
Update interlock-git.

### DIFF
--- a/archstrike/interlock-git/PKGBUILD
+++ b/archstrike/interlock-git/PKGBUILD
@@ -4,7 +4,7 @@ buildarch=220
 
 pkgname=interlock-git
 _pkgname=interlock
-pkgver=20170818.r354
+pkgver=20170905.r357
 pkgrel=1
 groups=('archstrike' 'archstrike-crypto')
 arch=('i686' 'x86_64' 'armv6h' 'armv7h' 'aarch64')


### PR DESCRIPTION
There is a new commit upstream fixing a cookie expiration issue which needed you to force to restart the daemon.