### PR TITLE
Add scannerl-git, the modular distributed fingerprinting engine

### DIFF
--- a/archstrike-testing/scannerl-git/.gitignore
+++ b/archstrike-testing/scannerl-git/.gitignore
@@ -1,0 +1,1 @@
+scannerl-git

--- a/archstrike-testing/scannerl-git/PKGBUILD
+++ b/archstrike-testing/scannerl-git/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: ArchStrike <team@archstrike.org>
+
+buildarch=1
+
+pkgname=scannerl-git
+pkgver=20171208.r46
+pkgrel=1
+groups=('archstrike' 'archstrike-scanner')
+arch=('any')
+pkgdesc="The modular distributed fingerprinting engine"
+url="https://github.com/kudelskisecurity/scannerl"
+license=('GPL3')
+depends=('erlang-nox')
+makedepends=('git' 'rebar')
+source=("${pkgname}::git+${url}.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd ${pkgname}
+  printf "%s.r%s" "$(git show -s --format=%ci master | sed "s/\ .*//g;s/-//g")" "$(git rev-list --count HEAD)"
+}
+
+build() {
+  cd ${pkgname}
+  ./build.sh
+}
+
+package() {
+  cd ${pkgname}
+  install -Dm755 scannerl "${pkgdir}/usr/bin/scannerl"
+
+  install -dm755 "${pkgdir}/usr/share/doc/${pkgname}"
+  install -Dm644 AUTHORS "${pkgdir}/usr/share/doc/${pkgname}/AUTHORS"
+  install -Dm644 DISCLAIMER.txt "${pkgdir}/usr/share/doc/${pkgname}/DISCLAIMER.txt"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}


### PR DESCRIPTION
This project aims to do large web scans and is currently, as their authors claim, the fastest one.

I'm open for any suggestions and improvements on this new package.