### PR TITLE
Fixed empire-setup script

### DIFF
--- a/archstrike/empire/PKGBUILD
+++ b/archstrike/empire/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=1
 _pkgname="Empire"
 pkgname=empire
 pkgver=2.5
-pkgrel=2
+pkgrel=3
 pkgdesc="A pure PowerShell post-exploitation agent."
 arch=('any')
 groups=('archstrike' 'archstrike-exploit' 'archstrike-backdoors')
@@ -71,7 +71,7 @@ if [[ -f "/usr/share/empire/data/empire.db" ]]; then
 fi
 echo "DB not found continuing with setup"
 cd /usr/share/empire/setup
-./setup_database.py
+python2 setup_database.py
 ./cert.sh
 EOF
 chmod 755 "${pkgdir}/usr/bin/empire-setup"


### PR DESCRIPTION
The empire-setup script attempts to execute setup_database.py which does
not have execution rights. This fixes it by running setup_database.py
with python2 directly. This reflects upstream changes made by commit
20462fc.