### PR TITLE
Updated burp to 2.1.04

### DIFF
--- a/archstrike/burpsuite/LICENSE
+++ b/archstrike/burpsuite/LICENSE
@@ -1,188 +1,268 @@
 
-Burp Suite Free Edition Licence Agreement
+Burp Suite Community Edition Licence Agreement
 
-This licence agreement (Licence) is a legal agreement between you (Licensee or you) and PORTSWIGGER LTD of 320 Garratt Lane, London, SW18 4EJ (Licensor or we) for a suite of tools designed for web application security testers (Burp Suite Free Edition or Software), which includes computer software, and the online documentation current at the date of the download of this Licence (Documentation).
+This licence agreement which incorporates the General Terms and Conditions below (Licence) forms part of the Terms for the Software, which includes computer software, and the online documentation current at the date of the download of this Licence and accessible on https://support.portswigger.net/ (Documentation).
 
-BURP SUITE FREE EDITION REQUIRES A COMPUTER WITH A MINIMUM OF 2GB OF MEMORY AND THE OFFICIAL JAVA RUNTIME ENVIRONMENT (VERSION 1.6 OR LATER). BY INSTALLING THE SOFTWARE YOU AGREE TO THE TERMS OF THIS LICENCE AND THE TERMS AND CONDITIONS OF THE LICENSOR WHICH WILL BIND YOU AND YOUR EMPLOYEES. IF YOU DO NOT AGREE TO THE TERMS OF THIS LICENCE AND THE TERMS AND CONDITIONS, WE ARE UNWILLING TO LICENSE THE SOFTWARE TO YOU AND YOU MUST DISCONTINUE THE INSTALLATION PROCESS NOW. IN THIS CASE THE INSTALLATION WILL TERMINATE.
+THE DOCUMENTATION CONTAINS THE SYSTEM REQUIREMENTS TO RUN BURP SUITE COMMUNITY EDITION . INTERNET ACCESS IS REQUIRED DURING INSTALLATION TO ACTIVATE THE SOFTWARE.
 
-WARNING: BURP SUITE FREE EDITION IS DESIGNED TO TEST FOR SECURITY FLAWS AND CAN DO DAMAGE TO TARGET SYSTEMS DUE TO THE NATURE OF ITS FUNCTIONALITY. TESTING FOR SECURITY FLAWS INHERENTLY INVOLVES INTERACTING WITH TARGETS IN NON-STANDARD WAYS WHICH CAN CAUSE PROBLEMS IN SOME VULNERABLE TARGETS. YOU MUST TAKE DUE CARE WHEN USING THE SOFTWARE, YOU MUST READ ALL DOCUMENTATION BEFORE USE, YOU SHOULD BACK UP TARGET SYSTEMS BEFORE USE AND YOU SHOULD NOT USE THE SOFTWARE ON PRODUCTION SYSTEMS OR OTHER SYSTEMS FOR WHICH THE RISK OF DAMAGE IS NOT ACCEPTED BY YOU.
+IF THE LICENSEE DOES NOT AGREE TO THE TERMS OF THE LICENCE AND THE BURP SUITE COMMUNITY EDITION TERMS AND CONDITIONS OF SUPPLY, THE LICENSOR IS UNWILLING TO LICENSE THE SOFTWARE TO THE LICENSEE AND (1) THE LICENSEE MUST NOT INSTALL THE SOFTWARE;AND/OR(2) WHERETHESOFTWAREHASALREADYBEENINSTALLED,THELICENSEE MUST CEASE USING IT IMMEDIATELY.
 
-1.    GRANT AND SCOPE OF LICENCE
+WARNING: BURP SUITE COMMUNITY EDITION IS DESIGNED TO TEST FOR SECURITY FLAWS AND CAN DO DAMAGE TO TARGET SYSTEMS DUE TO THE NATURE OF ITS FUNCTIONALITY. TESTING FOR SECURITY FLAWS INHERENTLY INVOLVES INTERACTING WITH TARGETS IN NON-STANDARD WAYS WHICH CAN CAUSE PROBLEMS IN SOME VULNERABLE TARGETS. THE LICENSEE MUST TAKE DUE CARE WHEN USING THE SOFTWARE, MUST READ ALL DOCUMENTATION BEFORE USE AND BACK UP TARGET SYSTEMS BEFORE USE. WHERE THE LICENSEE USES THE SOFTWARE ON PRODUCTION SYSTEMS OR OTHER SYSTEMS, IT EXPRESSLY HEREBY ACCEPTS THE RISK OF DAMAGE AND RISK OF LOSS OF DATA OR LOSS OF USE IN RESPECT OF SUCH DATA AND SYSTEMS AND ACCEPTS THAT IT SHOULD NOT USE THE SOFTWARE ON ANY SYSTEMS FOR WHICH IT DOES NOT ACCEPT THE RISK OF DAMAGE, RISK OF LOSS OF DATA OR LOSS OF USE.
 
-1.1    In consideration of you agreeing to abide by the terms of this Licence, the Licensor hereby grants to you a non-exclusive, non-transferable licence to use the Software and the Documentation on the terms of this Licence.
+1. GRANT AND SCOPE OF LICENCE
 
-1.2    You may either:
+1.1. In consideration of the Licensee agreeing to abide by the terms of the Licence, the Licensor hereby grants to the Licensee a non-exclusive, non-transferable licence to use the Software and the Documentation on the terms of the Licence. The Licence may be revoked by the Licensor at any time acting in its sole discretion.
 
-1.2.1    download, install and use the Software for your internal business purposes (which includes bespoke client consultancy, if appropriate) only; and
+1.2. The Licensee may:
 
-1.2.1.1    make one copy of the Software for back-up purposes only, provided that this is necessary for the activities permitted under condition 1.2.1;
+1.2.1. download, install and use the Software, including any Burp Apps (as defined in General Terms and Conditions, section 5) for its internal business purposes (which may, include the provision of a bespoke consultancy service to clients where the Licensee is acting in a business advisory capacity) only;
 
-1.2.1.2    receive and use any free supplementary software code or update of the Software incorporating "patches" and corrections of errors as may be provided by the Licensor from time to time on the basis that they are governed by the terms of this Licence;
+1.2.2. make one copy of the Software for back-up purposes only, provided that this is necessary for the activities permitted under section 1.2.1;
 
-1.2.1.3    use any Documentation in support of the use permitted under condition 1.2.1 and make such numbers of copies of the Documentation as are reasonably necessary for its lawful use; and
+1.2.3. use any Documentation in support of the use permitted under section 1.2.1 and make such numbers of copies of the Documentation as are reasonably necessary for its lawful use; and
 
-1.2.1.4    analyse the behaviour and performance of the documented functionality of the Software and disclose the findings of such analysis to any party provided that such findings are provided simultaneously and in identical form to the Licensor; or
+1.2.4. analyse the behaviour and performance of the documented functionality of the Software and any Burp Apps (defined as aforesaid) and disclose the findings of such analysis to any party provided that such findings are provided simultaneously and in identical form to the Licensor.
 
-1.2.2    transfer the Software to an end-user only provided that you procure that the end-user is bound by the terms of this Licence Agreement for the benefit of the Licensor and that you indemnify the Licensor against all costs (including legal costs) charges and expenses incurred by the Licensor as a result of the failure by you to comply with the provisions of this paragraph and/or the transfer by you of the Software to the end-user.
+1.3. The Licensee is not permitted to resell the Software.
 
-1.3    If you are an end-user who has obtained lawfully the Software other than by direct acquisition from the Licensor you may carry out the functions on the terms specified in paragraph 1.3.1 above and, during the Licence Period, you agree to be bound by this Licence Agreement directly in favour of the Licensor.
+2. LICENSEE'S WARRANTY AND UNDERTAKINGS
 
-2.    LICENSEE'S WARRANTY AND UNDERTAKINGS
+2.1. In addition to the warranties and undertakings given in the General Terms and Conditions, the Licensee undertakes to keep confidential any credentials provided by the Licensor enabling the Licensee to log in to the Licensor's server (for the purposes of downloading product builds and licence keys and to perform product activation, to create Extensions (as defined in General Terms and Conditions, section 2)).
 
-2.1    You warrant that you are not acquiring the Software as a consumer, but will be using the software in your business.
+3. LICENSOR'S LIABILITY: ATTENTION IS DRAWN PARTICULARLY TO THE PROVISIONS OF THIS CONDITION
 
-2.2    Except as expressly set out in this Licence or as permitted by any local law, you undertake:
+3.1. Subject to the General Terms and Conditions, section 6.1, the Licensor's maximum aggregate liability under or in connection with this Licence, or any collateral contract, whether in contract, tort (including negligence) or otherwise, shall be limited to twenty five pounds Sterling.
 
-2.2.1    not to use the Software or the Documentation for any unlawful purposes, particularly as Burp Suite Free Edition contains functionality that can be used to attack and compromise computer systems.
+GENERAL TERMS AND CONDITIONS
 
-2.2.2    to obtain all necessary authorisations from system owners prior to using Burp Suite Free Edition thereon;
+These terms and conditions are applicable to and form part of the Terms entered into between the Licensee and the Licensor for the Software and apply, unless specified or the context otherwise requires, whether the Software has been acquired either directly or indirectly by way of free download, pre-purchase or purchase on credit, free trial or by way of free licence for training purposes. Unless the context otherwise requires words and expressions used in the remainder of the Terms shall have the same meanings when used in these terms and conditions.
 
-2.2.3    unless agreed by the Licensor in writing not to copy the Software or Documentation except where such copying is incidental to normal use of the Software, or where it is necessary for the purpose of back-up or operational security;
+1. LICENSEE'S WARRANTY AND UNDERTAKINGS
 
-2.2.4    not to rent, lease, sub-license, loan, translate, merge, adapt, vary or modify the Software or Documentation;
+1.1. The Licensee warrants that it is not using licences to the Software as a consumer, but will be using the Software in its business and that any users placing orders for the Software and/or accepting these Terms are duly authorised by the Licensee to acquire licences to the Software.
 
-2.2.5    not to make alterations to, or modifications of, the whole or any part of the Software, nor permit the Software or any part of it to be combined with, or become incorporated in, any other programs;
+1.2. Except as expressly set out in the Licence or as permitted by any local law, the Licensee undertakes:
 
-2.2.6    not to disassemble, decompile, reverse engineer or create derivative works based on, the whole or any part of the Software nor attempt to do any such thing except to the extent that (by virtue of section 296A of the Copyright, Designs and Patents Act 1988) such actions cannot be prohibited because they are essential for the purpose of achieving inter-operability of the Software with another software program, and provided that the information obtained by you during such activities:
+1.2.1. not to use (or allow to be used) the Software, the Documentation for any unlawful purposes, particularly as the Software contains functionality that can be used to attack and compromise computer systems, and the Licensee shall be responsible for all losses, costs, liabilities or other damages incurred by the Licensor in connection with any claim by a third party in connection with a breach by the Licensee of this obligation;
 
-2.2.6.1    is used only for the purpose of achieving inter-operability of the Software with another software program; and
+1.2.2. to keep confidential any credentials provided by the Licensor enabling the Licensee to log in to the Licensor's server (for the purposes of downloading product builds and licence keys and to perform product activation, to create Extensions (as defined in section 5);
 
-2.2.6.2    is not unnecessarily disclosed or communicated without the Licensor's prior written consent to any third party; and
+1.2.3. to obtain all necessary authorisations from system owners prior to using the Software or any Burp Apps thereon;
 
-2.2.6.3    is not used to create any software which is substantially similar to the Software;
+1.2.4. unless agreed by the Licensor not to copy the Software or Documentation except where such copying is incidental to normal use of the Software, or where it is necessary for the purpose of back-up or operational security;
 
-2.2.7    to supervise and control use of the Software and ensure that the Software is used by your employees and representatives in accordance with the terms of this Licence;
+1.2.5. subject to the provisions of section 5, not to rent, lease, sub-license, loan, translate, merge, adapt, vary or modify the Software or Documentation;
 
-2.2.8    to replace the current version of the Software with any updated or upgraded version or new release provided by the Licensor under the terms of this Licence immediately on receipt;
+1.2.6. subject to the provisions of section 5, not to make alterations to, or modifications of, the whole or any part of the Software, nor permit the Software or any part of it to be combined with, or become incorporated in, any other programs;
 
-2.2.9    to include the copyright notice of the Licensor on all entire and partial copies you make of the Software on any medium;
+1.2.7. not to disassemble, decompile, reverse engineer or create derivative works based on, the whole or any part of the Software nor attempt to do any such thing except to the extent that (by virtue of section 296A of the Copyright, Designs and Patents Act 1988) such actions cannot be prohibited because they are essential for the purpose of achieving inter-operability of the Software with another software program, and provided that the information obtained by the Licensee during such activities:
 
-2.2.10    not to provide or otherwise make available the Software in whole or in part (including but not limited to program listings, object and source program listings, object code and source code), in any form to any person other than your employees without prior written consent from the Licensor;
+1.2.7.1. is used only for the purpose of achieving inter-operability of the Software with another software program; and
 
-2.2.11    unless specifically authorised by us in writing, not to use the Software as part of an automated service offering to third parties;
+1.2.7.2. is not unnecessarily disclosed or communicated without the Licensor's prior written consent to any third party; and
 
-2.2.12    not to engage in any activity, practice or conduct which would constitute an offence under sections 1, 2, or 6 of the Bribery Act 2010, if such activity, practice or conduct had been carried out in the UK;
+1.2.7.3. is not used to create any software which is substantially similar to the Software;
 
-2.2.13    to indemnify and keep indemnified the Licensor against all costs (including legal costs), charges and expenses incurred by the Licensor as a result of the failure by you to comply with the provisions of this Licence Agreement.
+1.2.8. to supervise and control use of the Software and ensure that the Software is used by the Licensee's employees and representatives in accordance with the terms of the Licence;
 
-3.    SUPPORT AND UPGRADES
+1.2.9. to replace the current version of the Software with any updated or upgraded version or new release provided by the Licensor to the Licensee via its account or the Software, immediately on receipt (and failure to do so may result in the Licensee's ineligibility for support pursuant to this Agreement);
 
-Downloading Burp Suite Free Edition does not entitle you to any product support. Although reasonable efforts may be made to support you if you are experiencing problems or bugs or require feature enhancements, any support will be provided at the Licensor’s sole discretion.
+1.2.10. to keep all copies of the Software secure and to maintain accurate and up-to-date records of the number of locations of all copies of the Software;
 
-4.    INTELLECTUAL PROPERTY RIGHTS
+1.2.11. to include the copyright notice of the Licensor on all entire and partial copies the Licensee makes of the Software on any medium;
 
-4.1    You acknowledge that all intellectual property rights in the Software and the Documentation anywhere in the world belong to the Licensor, that rights in the Software are licensed (not sold) to you, and that you have no rights in, or to, the Software or the Documentation other than the right to use them in accordance with the terms of this Licence.
+1.2.12. not to provide or otherwise make available the Software in whole or in part (including but not limited to program listings, object and source program listings, object code and source code), in any form to any person other than the Licensee's employees without prior written consent from the Licensor;
 
-4.2    You acknowledge that you have no right to have access to the Software in source code form
+1.2.13. unless specifically authorised by the Licensor in writing, not to use the Software as part of an automated service offering to third parties;
 
-4.3    The integrity of this Software is protected by technical protection measures (TPM) so that the intellectual property rights, including copyright, in the Software of the Licensor are not misappropriated. You must not attempt in any way to remove or circumvent any such TPM, nor apply or manufacture for sale or hire, import, distribute, sell or let for hire, offer or expose for sale or hire, advertise for sale or hire or have in your possession for private or commercial purposes any means the sole intended purpose of which is to facilitate the unauthorised removal or circumvention of such TPM.
+1.2.14. not to engage in any activity, practice or conduct which would constitute an offence under sections 1, 2, or 6 of the Bribery Act 2010, if such activity, practice or conduct had been carried out in the UK; and
 
-5.    LICENSOR’S WARRANTY
+1.2.15. to be responsible for all liability claims, actions, or causes of action, together with the legal costs of the Licensor in bringing the same, arising by reason of or in any way relating to the Licensee's actions or activities of its employees, agents, or contractors under the Licence.
 
-5.1    The Licensor warrants that for a period of 90 days from the download of the Software (Warranty Period) the Software will, when properly used, perform substantially in accordance with the functions described in the Documentation (provided that the Software is properly used on the computer and with the runtime environment for which it was designed as referred to herein).
+2. SUPPORT
 
-5.2    You acknowledge that the Software has not been developed to meet your individual requirements, and that it is therefore your responsibility to ensure that the facilities and functions of the Software as described in the Documentation meet your requirements.
+2.1. The downloading of a licence for the Software entitles the Licensee to free product support provided via the Licensor's support centre portal on its website at the Licensor's sole discretion. Such support will be subject to any support conditions, guidance or FAQs on https://support.portswigger.net/ from time to time.
 
-5.3    You acknowledge that the Software may not be free of bugs or errors, and agree that the existence of minor errors shall not constitute a breach of this Licence.
+3. BURP COLLABORATOR
 
-5.4    If, within the Warranty Period, you notify the Licensor in writing of any defect or fault in the Software in consequence of which it fails to perform substantially in accordance with the Documentation, and such defect or fault does not result from you having amended the Software or used it in contravention of the terms of this Licence, the Licensor will, at its sole option, either repair or replace the Software, provided that you make available all the information that may be necessary to help the Licensor to remedy the defect or fault, including sufficient information to enable the Licensor to recreate the defect or fault.
+3.1. The Licensor has developed Burp Collaborator which is a component of the Software's automated and manual testing tools available in respect of the Burp Suite Enterprise Edition and Burp Suite Professional Software and the terms of this section 3 shall only apply in respect of that Software. Burp Collaborator involves the Licensee deploying a system on the public web (the "Collaborator Server") which acts as the recipient of third-system interactions that may be triggered by payloads that the Software sends to target systems enabling the detection of certain types of vulnerability. A full description of the functionality of Burp Collaborator forms part of the Documentation if it applies to the version of the Software the Licensee has downloaded.
 
-6.    LICENSOR'S LIABILITY
+3.2. The functionality of Burp Collaborator gives rise to issues that require careful consideration by the Licensee as fully set out in the Documentation. By utilising any features of the Software that may cause interaction with Burp Collaborator, the Licensee will be deemed to have read the relevant Documentation, fully understood the functionality and the alternative methods of utilisation of Burp Collaborator and considered the consequences of utilisation for its organisation and as a result of such consideration has decided that Burp Collaborator, in the form utilised by it, is suitable and appropriate for use by it. The Licensor considers Burp Collaborator to be efficacious in identifying vulnerabilities of the target website in connection with third-system interactions, but the Licensee must make its own evaluation before using the Collaborator Server in any of the alternative manners set out in the Documentation.
 
-YOUR ATTENTION IS DRAWN PARTICULARLY TO THE PROVISIONS OF THIS CONDITION
+3.3. If the Licensee is permitted by the Licensor to use the Burp Collaborator server as part of a bespoke consultancy permitted under the terms of the Licence, by doing so the Licensee warrants to the Licensor that it has recommended the client to use the Burp Collaborator server in accordance with the terms of the Documentation and the client has instructed the Licensee to use the same having discussed with the Licensee the contents of the Documentation relating thereto.
 
-6.1    Nothing in this Licence shall limit or exclude the liability of either party for death or personal injury resulting from negligence, fraud, fraudulent misrepresentation.
+3.4. The Licensee acknowledges and accepts that by utilising the Burp Collaborator server either on its own behalf or on behalf of a client pursuant to a bespoke consultancy, the Licensor could be a Sub- Processor of its client's personal data under the provisions of the General Data Protection Regulation (Regulation (EU) 2016/679). If the Licensor does act as a Sub-Processor, it shall handle the Licensee or the Licensee's client's data in accordance with its Privacy Notice and as set out in the Documentation relating to Burp Collaborator.
 
-6.2    Subject to condition 6.1, the Licensor's liability for losses suffered by you arising out of or in connection with this agreement (including any liability for the acts or omissions of its employees, agents and subcontractors), whether arising in contract, tort (including negligence), misrepresentation or otherwise, shall not include liability for:
+4. BURP INFILTRATOR
 
-6.2.1    loss of turnover, sales or income;
+4.1. The Licensor has developed Burp Infiltrator which is a component of the Software for instrumenting deployed applications in order to facilitate testing using the Software in respect of the Burp Suite
 
-6.2.2    loss of business profits or contracts;
+Enterprise Edition and Burp Suite Professional Software and the terms of this section 4 shall only apply in respect of that Software. Burp Infiltrator involves the Licensee deploying or procuring deployment of the Infiltrator component within the target system which enhances the ability of the Software to detect certain types of vulnerability. A full description of the functionality of Burp Infiltrator forms part of the Documentation if it applies to the version of the Software the Licensee has downloaded.
 
-6.2.3    business interruption;
+4.2. The functionality of Burp Infiltrator gives rise to issues that require careful consideration by the user as fully set out in the Documentation. By deploying or procuring deployment of the Infiltrator tool, the Licensee will be deemed to have read the relevant Documentation, fully understood the functionality of Burp Infiltrator and considered the consequences of utilisation for its organisation and any bespoke consultancy clients of the Licensee and, as a result of such consideration, has decided that Burp Infiltrator is suitable and appropriate for use by it and by any client of the Licensee. The Licensor considers Burp Infiltrator to be efficacious in helping to identify vulnerabilities of the target website, but the Licensee must make its own evaluation before utilising Burp Infiltrator in the manner set out in the Documentation.
 
-6.2.4    loss of the use of money or anticipated savings;
+4.3. If the Licensee causes its client to install Burp Infiltrator as part of a bespoke consultancy permitted under the terms of the Licence, by so doing it warrants to the Licensor that it has recommended to the client to install Burp Infiltrator on its system and has discussed with the client the contents of the Documentation relating thereto and the potential consequences of such installation.
 
-6.2.5    loss of information;
+5. EXTENSIONS
 
-6.2.6    loss of opportunity, goodwill or reputation;
+5.1. In the Licence Agreement "Extension" means all programming additions made by a Licensee or on his behalf or with his concurrence to the Software using the Burp Extender API (as hereinafter defined) to either:
 
-6.2.7    loss of, damage to or corruption of software or data; or
+5.1.1. extend the functionality of the Software or any other software produced by the Licensor; or
 
-6.2.8    any indirect or consequential loss or damage of any kind howsoever arising and whether caused by tort (including negligence), breach of contract or otherwise;
+5.1.2. enable the Software or any other software produced by the Licensor to inter-operate with other
 
-provided that this condition 6.2 shall not prevent claims for loss of or damage to your tangible property that fall within the terms of condition 5 or any other claims for direct financial loss that are not excluded by any of categories 6.2.1 to 6.2.8 inclusive of this condition 6.2.
+software;
 
-6.3    Subject to condition 6.1, the Licensor's maximum aggregate liability under or in connection with this Licence, or any collateral contract, whether in contract, tort (including negligence) or otherwise, shall be limited to £50.
+but not to copy, clone, reproduce or emulate any existing feature of any software produced by the Licensor; and "Burp App" or "BApp" means an Extension adopted by the Licensor pursuant to this clause.
 
-6.4    Subject to condition 6.1, condition 6.2 and condition 6.3, the Licensor's liability for infringement of third-party intellectual property rights shall be limited to breaches of rights subsisting in the UK.
+5.2. "Burp Extender API" means the official Burp Extender application programming interface made available by PortSwigger Ltd and further described as part of the Documentation.
 
-6.5    This Licence sets out the full extent of the Licensor's obligations and liabilities in respect of the supply of the Software. In particular, there are no conditions, warranties, representations or other terms, express or implied, that are binding on the Licensor except as specifically stated in this Licence. Any condition, warranty, representation or other term concerning the supply of the Software which might otherwise be implied into, or incorporated in, this Licence, or any collateral contract, whether by statute, common law or otherwise, is hereby excluded to the fullest extent permitted by law.
+5.3. Extensions may be created for the use of the Licensee provided that if any such Extension is published (which, for the avoidance of doubt, shall include sharing such Extension with another licensee or a third party unless the party to which the Extension is provided is either a client of the Licensee and the relevant Extension has been created for use on an engagement for that or another client of the Licensee, or another Licensee within the Licensee's organisation) the Licensee shall notify the Licensor and provide to it a copy of such Extension and the Licensee agrees that any such Extension shall, at the option of the Licensor, become either:
 
-7.    TERMINATION
+5.3.1. a Burp App; or
 
-7.1    The Licensor may terminate this Licence immediately by written notice to you if you commit a material or persistent breach of this Licence which you fail to remedy (if remediable) within 14 days after the service of written notice requiring you to do so.
+5.3.2. part of the Software.
 
-7.2    Upon termination for any reason:
+5.4. When the creation of an Extension is notified to the Licensor or shared publicly and comes to the attention of the Licensor the Licensor has the option, in its sole discretion, to make the Extension a Burp App (Burp App, or BApp) after having carried out such diligence as it deems appropriate, on the Extension.
 
-7.2.1    all rights granted to you under this Licence shall cease;
+5.5. The Licensor has established the BApp Store product feature where Burp Apps are described and may be downloaded without charge for use as an Extension.
 
-7.2.2    you must cease all activities authorised by this Licence; and
+5.6. All Extensions and Burp Apps remain the property of the author but by creating such Extension, the author has granted an irrevocable, worldwide, perpetual, non-exclusive licence free of charge to the Licensor to incorporate such Extension in the Software and to use, copy, modify and adapt it for any purpose at the Licensor's option and an irrevocable, perpetual, non-exclusive licence to use the Extension free of charge to all third party licensees who download the Burp App from the BApp Store.
 
-7.2.3    you must immediately delete or remove the Software from all computer equipment in your possession, and immediately destroy or return to the Licensor (at the Licensor's option) all copies of the Software then in your possession, custody or control and, in the case of destruction, certify to the Licensor that you have done so.
+5.7. If, at the sole option of the Licensor, the Licensor incorporates an Extension into the Software a notice will be placed on the BApp Store to that effect.
 
-8.    TRANSFER OF RIGHTS AND OBLIGATIONS
+5.8. The Licensor retains the right, without incurring any liability to the Licensee, to disable without notice any Burp App being used by the Licensee where the Licensor considers in its sole discretion that it is necessary to do so for operational, security or quality reasons.
 
-8.1    This Licence is binding on you and us, and on our respective successors and assigns.
+6. THIRD PARTY SOFTWARE
 
-8.2    You may not transfer, assign, charge or otherwise dispose of this Licence, or any of your rights or obligations arising under it, without our prior written consent.
+The Software may make use of third party technology that is provided with the Software. The Licensor may provide certain notices to the Licensee in the Documentation, readmes or notice files in connection with such third party technology. Third party technology will be licensed to the Licensee either under the terms of this License or, if specified in the Documentation, readmes or notice files, under separate terms or as otherwise notified to the Licensor by the Licensee.
 
-8.3    We may transfer, assign, charge, sub-contract or otherwise dispose of this Licence, or any of our rights or obligations arising under it, at any time during the term of the Licence.
+7. INTELLECTUAL PROPERTY RIGHTS
 
-9.    NOTICES
+7.1. The Licensee acknowledges that all intellectual property rights in the Software and the Documentation anywhere in the world belong to the Licensor, that rights in the Software are licensed (not sold) to the Licensee, and that the Licensee has no rights in, or to, the Software or the Documentation other than the right to use them in accordance with the terms of the Licence.
 
-All notices given by you to us must be given to PortSwigger Ltd at office@portswigger.net or 320 Garratt Lane, London, SW18 4EJ. We may give notice to you at either the e-mail or postal address you provided to us when downloading the Software or provided in other communications from you to us. Notice will be deemed received and properly served immediately when posted on our website, 24 hours after an e-mail is sent, or three days after the date of posting of any letter. In proving the service of any notice, it will be sufficient to prove, in the case of a letter, that such letter was properly addressed, stamped and placed in the post and, in the case of an e-mail, that such e-mail was sent to the specified e-mail address of the addressee.
+7.2. The Licensee acknowledges that it has no right to have access to the Software in source code form.
 
-10.    EVENTS OUTSIDE OUR CONTROL
+7.3. The integrity of this Software is protected by technical protection measures (TPM) so that the intellectual property rights, including copyright, in the Software of the Licensor are not misappropriated. The Licensee must not attempt in any way to remove or circumvent any such TPM, nor apply or manufacture for sale or hire, import, distribute, sell or let for hire, offer or expose for sale or hire, advertise for sale or hire or have in its possession for private or commercial purposes any means the sole intended purpose of which is to facilitate the unauthorised removal or circumvention of such TPM.
 
-10.1    We will not be liable or responsible for any failure to perform, or delay in performance of, any of our obligations under this Licence that is caused by events outside our reasonable control (Force Majeure Event).
+7.4. The Licensor will defend Licensee against any claim, demand, suit or proceeding made or brought against Licensee by a third party alleging that any Software or services infringe or misappropriate such third party's intellectual property rights (a "Third Party IPR Claim"), and will indemnify Licensee from any direct damages, finally awarded against Licensee as a result of, or for amounts paid by Licensee under a settlement approved by Licensor in writing of, a Third Party IPR Claim, provided that, in each case the Licensee:
 
-10.2    A Force Majeure Event includes any act, event, non-happening, omission or accident beyond our reasonable control and includes in particular (without limitation) the following:
+7.4.1. promptly gives Licensor written notice of the Third Party IPR Claim;
 
-10.2.1    strikes, lock-outs or other industrial action;
+7.4.2. gives the Licensor, at its sole option, the sole control of the defence and settlement of the Third Party IPR Claim; and
 
-10.2.2    civil commotion, riot, invasion, terrorist attack or threat of terrorist attack, war (whether declared or not) or threat or preparation for war;
+7.4.3. gives Licensor all reasonable assistance, at Licensor's expense.
 
-10.2.3    fire, explosion, storm, flood, earthquake, subsidence, epidemic or other natural disaster;
+If Licensor receives information about an infringement or misappropriation claim related to the Software or services, Licensor may in its discretion and at no cost to Licensee (i) modify the Software or services so that they are no longer claimed to infringe or misappropriate, (ii) obtain a license for Licensee's continued use of the Software or services in accordance with this Agreement, or (iii) terminate Licensee's subscriptions for such Software or services upon 30 days' written notice and refund Licensee any prepaid fees covering the remainder of the term of the terminated licence. The above defence and indemnification obligations do not apply if (1) the allegation does not state with specificity that the Software or services are the basis of the Third Party Claim; (2) a Third Party Claim arises from the use or combination of the Software or services or any part thereof with software, hardware, data, or processes not provided by Licensor, if the Software or Services or use thereof would not infringe without such combination; (3) a Third Party Claim arises from Software or services for which there is no charge or has been provided on a free trial or community licence basis; or (4) a Third Party Claim arises from the Licensee's or a third party's materials or application or Licensee's breach of this Agreement. This clause provides the Licensor's sole liability to, and the Licensee's exclusive remedy against, the Licensor for any Third Party IPR Claim.
 
-10.2.4    impossibility of the use of railways, shipping, aircraft, motor transport or other means of public or private transport;
+8. LICENSOR'S WARRANTY
 
-10.2.5    impossibility of the use of public or private telecommunications networks;
+8.1. The Licensee acknowledges that the Software and the Burp Apps are provided "as is" and have not been developed to meet its individual requirements, and that it is therefore the Licensee's responsibility to ensure that the facilities and functions of the Software as described in the Documentation and the facilities and functions of any Burp App meet its requirements.
 
-10.2.6    the acts, decrees, legislation, regulations or restrictions of any government.
+8.2. The Licensee acknowledges that the Software and the Burp Apps may not be free of bugs or errors, and agree that the existence of minor errors shall not constitute a breach of the Licence.
 
-10.3    Our performance under this Licence is deemed to be suspended for the period that the Force Majeure Event continues, and we will have an extension of time for performance for the duration of that period. We will use our reasonable endeavours to bring the Force Majeure Event to a close or to find a solution by which our obligations under this Licence may be performed despite the Force Majeure Event.
+9. LICENSOR'S LIABILITY: ATTENTION IS DRAWN PARTICULARLY TO THE PROVISIONS OF THIS CONDITION
 
-11.    WAIVER
+9.1. Nothing in the Licence shall limit or exclude the liability of either party for death or personal injury resulting from negligence, fraud, fraudulent misrepresentation or any other liability that cannot be limited by law.
 
-11.1    If we fail, at any time during the term of this Licence, to insist upon strict performance of any of your obligations under this Licence, or if we fail to exercise any of the rights or remedies to which we are entitled under this Licence, this shall not constitute a waiver of such rights or remedies and shall not relieve you from compliance with such obligations.
+9.2. Subject to section 9.1, the Licensor's liability for losses suffered by the Licensee arising out of or in connection with the Licence (including any liability for the acts or omissions of its employees, agents and subcontractors), whether arising in contract, tort (including negligence), misrepresentation or otherwise, shall not include liability for:
 
-11.2    A waiver by us of any default shall not constitute a waiver of any subsequent default.
+9.2.1. loss of turnover, sales or income;
 
-11.3    No waiver by us of any of these terms and conditions shall be effective unless it is expressly stated to be a waiver and is communicated to you in writing.
+9.2.2. loss of business profits or contracts;
 
-12.    SEVERABILITY
+9.2.3. business interruption;
 
-If any of the terms of this Licence are determined by any competent authority to be invalid, unlawful or unenforceable to any extent, such term, condition or provision will to that extent be severed from the remaining terms, conditions and provisions which will continue to be valid to the fullest extent permitted by law.
+9.2.4. loss of the use of money or anticipated savings;
 
-13.    ENTIRE AGREEMENT
+9.2.5. loss of information;
 
-13.1    This Licence and any document expressly referred to in it represents the entire agreement between us in relation to the licensing of the Software and the Documentation and supersedes any prior agreement, understanding or arrangement between us, whether oral or in writing.
+9.2.6. loss of opportunity, goodwill or reputation;
 
-13.2    We each acknowledge that, in entering into this Licence, neither of us has relied on any representation, undertaking or promise given by the other or implied from anything said or written in negotiations between us prior to entering into this Licence except as expressly stated in this Licence.
+9.2.7. loss of, damage to or corruption of software or data; or
 
-13.3    Neither of us shall have any remedy in respect of any untrue statement made by the other, whether orally or in writing, prior to the date we entered into this Licence (unless such untrue statement was made fraudulently) and the other party's only remedy shall be for breach of contract as provided in these terms and conditions.
+9.2.8. any indirect or consequential loss or damage of any kind howsoever arising and whether caused by tort (including negligence), breach of contract or otherwise.
 
-14.    LAW AND JURISDICTION
+9.3. The Licence sets out the full extent of the Licensor's obligations and liabilities in respect of the supply of the Software and Burp Apps. In particular, there are no conditions, warranties, representations or other terms, express or implied, that are binding on the Licensor except as specifically stated in the Licence. Any condition, warranty, representation or other term concerning the supply of the Software and Burp Apps which might otherwise be implied into, or incorporated in, the Licence, or any collateral contract, whether by statute, common law or otherwise, is hereby excluded to the fullest extent permitted by law.
 
-This Licence, its subject matter or its formation (including non-contractual disputes or claims) shall be governed by and construed in accordance with English law and submitted to the exclusive jurisdiction of the English courts.
+10. PUBLICITY AND COMMUNICATION
+
+10.1. By entering into the Licence the Licensee agrees that the Licensor may refer to the Licensee as one of its customers internally and in externally published media and, where relevant, the Licensee grants its consent to the use of the Licensee's logo(s) for this purpose, unless the Licensee notifies the Licensor in writing that the Licensor may not refer to it for such purpose. Any additional disclosure by the Licensor with respect to the Licensee shall be subject to its prior written consent.
+
+10.2. By entering into the Licence, the Licensee consents that the Licensor may process the personal data that it collects from the Licensee in accordance with the Licensor's Privacy Policy. The Licensee is responsible for ensuring it has in place all relevant consents, permissions or rights to share any personal data with the Licensor for the Licensor's use in accordance with the Privacy Policy and these Terms. In particular, the Licensor may use information it holds about the Licensee or its designated contacts for the purposes of, inter alia, sending out renewal reminders, questionnaires to certain categories of users including non-renewers and feedback requests.
+
+10.3. Any questions, comments and requests regarding the Licensor's data processing practices may be addressed to office@portswigger.net.
+
+11. TERMINATION
+
+11.1. The Licensor may terminate the Licence immediately by written notice to the Licensee if the Licensee or any of its users commit a material or persistent breach of the Licence which the Licensee fails to remedy (if remediable) within 14 days after the service of written notice requiring the Licensee to do so.
+
+11.2. Upon termination for any reason:
+
+11.2.1. all rights granted to the Licensee under the Licence shall cease;
+
+11.2.2. the Licensee must cease all activities authorised by the Licence;
+
+11.2.3. the Licensee must immediately delete or remove the Software and any Burp Apps from all computer equipment in its possession, and immediately destroy or return to the Licensor (at the Licensor's option) all copies of the Software and Burp Apps then in its possession, custody or control and, in the case of destruction, certify to the Licensor that it have done so; and
+
+11.2.4. the Licensee must immediately pay to the Licensor any sums due to the Licensor under the Licence.
+
+12. TRANSFER OF RIGHTS AND OBLIGATIONS
+
+12.1. The Licence is binding on the Licensee and the Licensor, and each of their respective successors and assigns.
+
+12.2. The Licensee may not transfer, assign, charge or otherwise dispose of the Licence, or any of its rights or obligations arising under it, without the Licensor's prior written consent.
+
+12.3. Where Licensee is a company, the licenses granted hereunder shall also extend to the Licensee's Group members (meaning, in relation to any company, that company, its subsidiaries, its ultimate holding company and all subsidiaries of such ultimate holding company, as such terms are defined in the Companies Act 2006), provided that such Group members have no right under the Contracts (Rights of Third Parties) Act 1999 to enforce any term of the Agreement.
+
+12.4. The Licensor may transfer, assign, charge, sub-contract or otherwise dispose of the Licence, or any of the Licensor's rights or obligations arising under it, at any time during the term of the Licence.
+
+13. NOTICES
+
+All notices given by the Licensee to the Licensor must be given to PortSwigger Ltd at office@portswigger.net or Victoria Court, Bexton Road, Knutsford, WA16 0PF England. The Licensor may give notice to the Licensee posting online on the Licensor website. Notice will be deemed received and properly served immediately when posted on the Licensor's website. In proving the service of any notice, it will be sufficient to prove, in the case of a letter, that such letter was properly addressed, stamped and placed in the post and, in the case of an e-mail, that such e-mail was sent to the specified e-mail address of the addressee.
+
+14. EVENTS OUTSIDE LICENSOR'S CONTROL
+
+14.1. The Licensor will not be liable or responsible for any failure to perform, or delay in performance of, any of the Licensor's obligations under the Licence that is caused by events outside its reasonable control (Force Majeure Event).
+
+14.2. A Force Majeure Event includes any act, event, non-happening, omission or accident beyond the Licensor's reasonable control and includes in particular (without limitation) the following:
+
+14.2.1. strikes, lock-outs or other industrial action;
+
+14.2.2. civil commotion, riot, invasion, terrorist attack or threat of terrorist attack, war (whether declared or not) or threat of or preparation for war;
+
+14.2.3. fire, explosion, storm, flood, earthquake, subsidence, epidemic or other natural disaster;
+
+14.2.4. impossibility of the use of railways, shipping, aircraft, motor transport or other means of public or private transport;
+
+14.2.5. impossibility of the use of public or private telecommunications networks; and
+
+14.2.6. the acts, decrees, legislation, regulations or restrictions of any government.
+
+14.3. The Licensor's performance under the Licence is deemed to be suspended for the period that the Force Majeure Event continues, and the Licensor will have an extension of time for performance for the duration of that period. The Licensor will use its reasonable endeavours to bring the Force Majeure
+
+Event to a close or to find a solution by which its obligations under the Licence may be performed despite the Force Majeure Event.
+
+15. WAIVER
+
+15.1. If the Licensor fails, at any time during the term of the Licence, to insist upon strict performance of any of the Licensee's obligations under the Licence, or if the Licensor fails to exercise any of the rights or remedies to which the Licensor is entitled under the Licence, this shall not constitute a waiver of such rights or remedies and shall not relieve the Licensee from compliance with such obligations.
+
+15.2. A waiver by the Licensor of any default shall not constitute a waiver of any subsequent default.
+
+15.3. No waiver by the Licensor of any of the provisions of the Licence shall be effective unless it is expressly stated to be a waiver and is communicated to the Licensee in writing.
+
+16. SEVERABILITY
+
+If any of the terms of the Licence are determined by any competent authority to be invalid, unlawful or unenforceable to any extent, such term, condition or provision will to that extent be severed from the remaining terms, conditions and provisions which will continue to be valid to the fullest extent permitted by law.
+
+17. ENTIRE AGREEMENT
+
+17.1. This Licence and any document expressly referred to in it represents the entire agreement between the parties in relation to the licensing of the Software, the Documentation and any Burp Apps and supersedes any prior agreement, understanding or arrangement between the parties, whether oral or in writing.
+
+17.2. The parties each acknowledge that, in entering into the Licence, they have not relied on any representation, undertaking or promise given by the other or implied from anything said or written in negotiations between the parties prior to entering into the Licence except as expressly stated in the Licence.
+
+17.3. Neither party shall have any remedy in respect of any untrue statement made by the other, whether orally or in writing, prior to the date on which the parties entered into this Licence (unless such untrue statement was made fraudulently) and the other party's only remedy shall be for breach of contract as provided in these terms and conditions.
+
+18. LAW AND JURISDICTION
+
+The Licence, its subject matter or its formation (including non-contractual disputes or claims) shall be governed by and construed in accordance with English law and submitted to the exclusive jurisdiction of the English courts.

--- a/archstrike/burpsuite/PKGBUILD
+++ b/archstrike/burpsuite/PKGBUILD
@@ -1,21 +1,22 @@
 # Maintainer: ArchStrike <team@archstrike.org>
+# Contributor: Lukas Kempf <archstrike@lukas-kempf.de>
 
 buildarch=1
 
 pkgname=burpsuite
-pkgver=1.7.36
+pkgver=2.1.04
 pkgrel=1
 groups=('archstrike' 'archstrike-webapps' 'archstrike-scanners' 'archstrike-fuzzers' 'archstrike-proxy')
 pkgdesc="An integrated platform for attacking web applications (free edition)."
 url='http://portswigger.net/burp/'
-depends=('java-environment' 'bash')
+depends=('jre11-openjdk' 'bash')
 arch=('any')
 license=('custom')
 noextract=("burpsuite.jar")
-source=("burpsuite.jar::https://portswigger.net/Burp/Releases/Download?productId=100&version=${pkgver}&type=Jar" "LICENSE")
-sha512sums=('9788720feed1227f196adc7b4de78793de9a2e4602bdf066a37d482bc2f5a9d7c04773ca8325f953591db81125b7d117f77f7a8f9c8dc461e795ea44af4e1cab'
-            '37abc24b19571bfd2941e3dd7aa8a8a330bd3bbbafb3d1f813035ab0313e189c1f4a43a68f820a32656b86dd29cca94afcaefc6a4bfb4219ef18dc0fc4923b86')
-
+source=("burpsuite.jar::https://portswigger.net/Burp/Releases/Download?productId=100&version=${pkgver}&type=Jar" "LICENSE" "burpsuite.desktop")
+sha512sums=('77ee9fc73eeb99745b05a917709bbba0fd125a107889380a8b3e47f0c9380a281c28079a17a5854fd631fbf7efa9bccc810bfd1c6077548e7c642af8643ffc75'
+            '3bc6083224e3b6fd777b0fbb2aea73ce6fdd21011d1c6ceb0a5298c6278d04d35f7e5f6fd7e5dd621331fa4060eceb0655ffd63d6a5214833f6fbaa6f14a3681'
+            '076f2f7ca3096a44a3ccf8b9f723384e0c335b3f4391f26b4d8d652716a1e2b7325e4aa1ad7ea3d711073a77292fa19857e2881dbd909d547d28a806fc65e0cf')
 package() {
   cd ${srcdir}
 
@@ -27,10 +28,13 @@ package() {
   install -Dm755 burpsuite.jar $pkgdir/usr/share/${pkgname}/burpsuite.jar
   install -Dm644 LICENSE $pkgdir/usr/share/licenses/${pkgname}
 
+  install -Dm644 "$pkgname.desktop" "$pkgdir/usr/share/applications/$pkgname.desktop"
+
 # Make joint script.
 cat > ${pkgdir}/usr/bin/burpsuite <<EOF
 #!/usr/bin/env bash
-exec \$JAVA_HOME/bin/java -jar /usr/share/${pkgname}/burpsuite.jar "\$@"
+export PATH=/usr/lib/jvm/java-11-openjdk/bin/:\$PATH
+exec java -jar /usr/share/${pkgname}/burpsuite.jar "\$@"
 EOF
 chmod 755 ${pkgdir}/usr/bin/burpsuite
 }

--- a/archstrike/burpsuite/burpsuite.desktop
+++ b/archstrike/burpsuite/burpsuite.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Burpsuite
+Comment=An integrated platform for attacking web applications (free edition).
+Exec=burpsuite
+Icon=archstrike-menu.png
+Terminal=false
+StartupNotify=false
+Categories=ArchStrike;ArchStrikeWebapp;ArchStrikeFuzzer;ArchStrikeScanner;ArchStrikeProxy;


### PR DESCRIPTION
The version of burpsuite in arch strike is quite ancient. In addition to updating I also made a couple of improvements. The package now has a .desktop file and it will use jre 11. This is the current LTS release and there are compatibility issues when using jre 12.

I haven't included the package because it is 300mb large.  
```
$ namcap PKGBUILD
PKGBUILD (burpsuite) W: Non standard variable 'buildarch' doesn't start with an underscore
$ namcap burpsuite-2.1.04-1-any.pkg.tar.xz 
burpsuite W: Dependency bash included but already satisfied
```